### PR TITLE
Add CBZ output, CLI URL argument, and reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **CBZ archive creation**: after an album finishes downloading, all images are packaged
+  into a `.cbz` comic archive (zero-padded for correct page order) saved in the `Downloads`
+  folder.
+- **Resume support**: already-downloaded images are detected and skipped, so an interrupted
+  run can be restarted without re-downloading the pages it already has.
+
+## [1.0.1] - 2026-03-19
+
+### Changed
+
+- Migrated project to a `src/` layout for a cleaner, more modular structure.
+
+## [1.0.0] - 2025-08-04
+
+### Added
+
+- Single-album and batch downloads from E-Hentai URLs.
+- Concurrent image downloads with rate limiting and retry handling.
+- Live progress tracking and session logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **CBZ archive creation**: after an album finishes downloading, all images are packaged
-  into a `.cbz` comic archive (zero-padded for correct page order) saved in the `Downloads`
-  folder.
-- **Resume support**: already-downloaded images are detected and skipped, so an interrupted
-  run can be restarted without re-downloading the pages it already has.
+  into a `.cbz` comic archive (zero-padded for correct page order). The archive is saved
+  inside the album's own folder and the extracted images are removed afterwards.
+- **CLI album URL**: `python3 main.py <album_url>` downloads a single album directly;
+  the `URLs.txt` batch file is only used (and cleared) when no URL is given.
+
+### Changed
+
+- **Overall progress accuracy**: the overall progress bar now tracks downloaded images
+  against the album's total image count, instead of one tick per finished page.
+- **Resume support**: already-downloaded images are skipped, and downloads write to
+  `.part` temp files first so an interrupted run never fakes a completed image.
+
+### Fixed
+
+- Crash on single-page albums (`next_pages[-2]` IndexError).
+- Crash when an image page lacks the expected `nl` element or download link.
+- Wrong CBZ page order (images were sorted by hash filename instead of download order).
+- CBZ path failing when the album title contains path-hostile characters like `/`.
 
 ## [1.0.1] - 2026-03-19
 

--- a/main.py
+++ b/main.py
@@ -35,12 +35,15 @@ async def main() -> None:
     clear_terminal()
     write_file(SESSION_LOG)
 
-    # Read and process URLs, ignoring empty lines
-    urls = [url.strip() for url in read_file(URLS_FILE) if url.strip()]
-    await process_urls(urls)
+    # Use the command-line URL if provided, otherwise fall back to URLs.txt
+    if len(sys.argv) > 1:
+        urls = [sys.argv[1]]
+    else:
+        urls = [url.strip() for url in read_file(URLS_FILE) if url.strip()]
+        # Clear URLs file
+        write_file(URLS_FILE)
 
-    # Clear URLs file
-    write_file(URLS_FILE)
+    await process_urls(urls)
 
 
 if __name__ == "__main__":

--- a/src/crawler/crawler.py
+++ b/src/crawler/crawler.py
@@ -60,15 +60,22 @@ class Crawler:
         for picture_page in picture_pages:
             soup = fetch_page(picture_page)
             nl_container = soup.find("a", {"id": "loadfail", "onclick": True})
-            nl_value = re.search(NL_VALUE_PATTERN, nl_container.get("onclick")).group(1)
 
-            if nl_value:
-                reloaded_page = generate_reloaded_page(picture_page, nl_value)
-                reloaded_pages.append(reloaded_page)
-            else:
+            if nl_container is None:
+                self.live_manager.update_log(
+                    "Missing 'nl' value", f"No loadfail element for {picture_page}.",
+                )
+                continue
+
+            match = re.search(NL_VALUE_PATTERN, nl_container.get("onclick", ""))
+            if match is None:
                 self.live_manager.update_log(
                     "Missing 'nl' value", f"No 'nl' value found for {picture_page}.",
                 )
+                continue
+
+            reloaded_page = generate_reloaded_page(picture_page, match.group(1))
+            reloaded_pages.append(reloaded_page)
 
         return reloaded_pages
 
@@ -79,6 +86,8 @@ class Crawler:
             "a",
             {"href": pattern, "onclick": "return false"},
         )
+        if len(next_pages) < 2:
+            return []
 
         last_page_url = next_pages[-2].get("href")
         match = re.search(r"\?p=(\d+)", last_page_url)

--- a/src/downloader/album_downloader.py
+++ b/src/downloader/album_downloader.py
@@ -54,9 +54,14 @@ class AlbumDownloader:
         album_pages_soups = self.crawler.collect_album_pages_soups()
         session = requests.Session()
         num_pages = len(album_pages_soups)
+        num_images = sum(
+            len(get_picture_pages(soup.find_all("a", {"href": True})))
+            for soup in album_pages_soups
+        )
         self.live_manager.add_overall_task(
             description=self.album_name,
-            num_tasks=num_pages,
+            num_tasks=num_images,
+            num_pages=num_pages,
         )
 
         for current_task, soup in enumerate(album_pages_soups):

--- a/src/downloader/album_downloader.py
+++ b/src/downloader/album_downloader.py
@@ -7,6 +7,7 @@ tracking.
 
 import random
 import time
+import zipfile
 from pathlib import Path
 
 import requests
@@ -14,6 +15,7 @@ from requests import Response, Session
 
 from src.config import (
     CHUNK_SIZE,
+    DOWNLOAD_FOLDER,
     HTTP_RATE_LIMIT,
     RATE_LIMIT_SLEEPING_TIME,
 )
@@ -79,6 +81,31 @@ class AlbumDownloader:
                 )
                 time.sleep(random.uniform(1, 5))  # noqa: S311
 
+        self._create_cbz()
+
+    def _create_cbz(self) -> None:
+        """Create a CBZ archive from downloaded images in order."""
+        image_files = sorted(
+            p for p in Path(self.download_path).glob("*")
+            if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+        )
+        if not image_files:
+            self.live_manager.update_log("CBZ creation", "No images found to archive")
+            return
+
+        cbz_name = f"{self.album_name}.cbz"
+        cbz_path = Path(DOWNLOAD_FOLDER) / cbz_name
+
+        with zipfile.ZipFile(cbz_path, "w", zipfile.ZIP_DEFLATED) as cbz:
+            for i, img_path in enumerate(image_files):
+                # Use zero-padded index for correct ordering in CBZ
+                arcname = f"{i:03d}{img_path.suffix}"
+                cbz.write(img_path, arcname)
+
+        self.live_manager.update_log(
+            "CBZ created", f"Archive saved to {cbz_path}"
+        )
+
     def download_picture(
             self,
             response: Response,
@@ -109,6 +136,12 @@ class AlbumDownloader:
             soup = fetch_page(reloaded_page)
             download_link_container = soup.find("img", {"id": "img", "src": True})
             download_link = download_link_container.get("src")
+            filename = download_link.split("/")[-1]
+
+            final_path = Path(self.download_path) / filename
+            if final_path.is_file():
+                self.live_manager.update_task(task, advance=1)
+                continue
 
             headers = prepare_headers(download_link)
             session.headers.update(headers)
@@ -130,7 +163,6 @@ class AlbumDownloader:
                 )
                 time.sleep(RATE_LIMIT_SLEEPING_TIME)
 
-            filename = download_link.split("/")[-1]
             self.download_picture(response, filename, task)
             time.sleep(random.uniform(1.5, 4.0))  # noqa: S311
 

--- a/src/downloader/album_downloader.py
+++ b/src/downloader/album_downloader.py
@@ -15,7 +15,6 @@ from requests import Response, Session
 
 from src.config import (
     CHUNK_SIZE,
-    DOWNLOAD_FOLDER,
     HTTP_RATE_LIMIT,
     RATE_LIMIT_SLEEPING_TIME,
 )
@@ -99,14 +98,16 @@ class AlbumDownloader:
             self.live_manager.update_log("CBZ creation", "No images found to archive")
             return
 
-        cbz_name = f"{self.album_name}.cbz"
-        cbz_path = Path(DOWNLOAD_FOLDER) / cbz_name
+        cbz_path = Path(self.download_path) / f"{self.album_name}.cbz"
 
         with zipfile.ZipFile(cbz_path, "w", zipfile.ZIP_DEFLATED) as cbz:
             for i, img_path in enumerate(image_files):
                 # Use zero-padded index for correct ordering in CBZ
                 arcname = f"{i:03d}{img_path.suffix}"
                 cbz.write(img_path, arcname)
+
+        for img_path in image_files:
+            img_path.unlink()
 
         self.live_manager.update_log(
             "CBZ created", f"Archive saved to {cbz_path}"

--- a/src/downloader/album_downloader.py
+++ b/src/downloader/album_downloader.py
@@ -47,6 +47,7 @@ class AlbumDownloader:
         )
         self.album_name = self.crawler.get_album_name()
         self.download_path = create_download_directory(self.album_name)
+        self.image_counter = 0
 
     def download_album(self) -> None:
         """Download all images from the album while tracking progress."""
@@ -84,7 +85,7 @@ class AlbumDownloader:
         self._create_cbz()
 
     def _create_cbz(self) -> None:
-        """Create a CBZ archive from downloaded images in order."""
+        """Create a CBZ archive from downloaded images in page order."""
         image_files = sorted(
             p for p in Path(self.download_path).glob("*")
             if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp", ".gif"}
@@ -114,9 +115,11 @@ class AlbumDownloader:
         ) -> None:
         """Save an image response to a file and update the progress."""
         final_path = Path(self.download_path) / filename
-        with Path(final_path).open("wb") as file:
+        temp_path = final_path.with_suffix(final_path.suffix + ".part")
+        with temp_path.open("wb") as file:
             for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
                 file.write(chunk)
+        temp_path.replace(final_path)
 
         self.live_manager.update_task(task, advance=1)
 
@@ -135,11 +138,29 @@ class AlbumDownloader:
         for reloaded_page in reloaded_pages:
             soup = fetch_page(reloaded_page)
             download_link_container = soup.find("img", {"id": "img", "src": True})
+            if download_link_container is None:
+                self.live_manager.update_log(
+                    "Failed download",
+                    f"No image found on {reloaded_page}, check the log file",
+                )
+                failed_downloads.append(reloaded_page)
+                write_on_session_log(reloaded_page)
+                self.image_counter += 1
+                continue
             download_link = download_link_container.get("src")
-            filename = download_link.split("/")[-1]
-
-            final_path = Path(self.download_path) / filename
+            if not download_link:
+                self.live_manager.update_log(
+                    "Failed download",
+                    f"No image found on {reloaded_page}, check the log file",
+                )
+                failed_downloads.append(reloaded_page)
+                write_on_session_log(reloaded_page)
+                self.image_counter += 1
+                continue
+            suffix = Path(download_link.split("/")[-1].split("?")[0]).suffix
+            final_path = Path(self.download_path) / f"{self.image_counter:03d}{suffix}"
             if final_path.is_file():
+                self.image_counter += 1
                 self.live_manager.update_task(task, advance=1)
                 continue
 
@@ -154,6 +175,7 @@ class AlbumDownloader:
                 )
                 failed_downloads.append(download_link)
                 write_on_session_log(download_link)
+                self.image_counter += 1
                 continue
 
             if response.status_code == HTTP_RATE_LIMIT:
@@ -163,7 +185,8 @@ class AlbumDownloader:
                 )
                 time.sleep(RATE_LIMIT_SLEEPING_TIME)
 
-            self.download_picture(response, filename, task)
+            self.download_picture(response, f"{self.image_counter:03d}{suffix}", task)
+            self.image_counter += 1
             time.sleep(random.uniform(1.5, 4.0))  # noqa: S311
 
         return failed_downloads

--- a/src/downloader/album_downloader.py
+++ b/src/downloader/album_downloader.py
@@ -20,7 +20,7 @@ from src.config import (
 )
 from src.crawler.crawler import Crawler
 from src.crawler.crawler_utils import get_picture_pages
-from src.file_utils import create_download_directory, write_on_session_log
+from src.file_utils import create_download_directory, sanitize_directory_name, write_on_session_log
 from src.general_utils import fetch_page
 from src.managers.live_manager import LiveManager
 
@@ -98,7 +98,7 @@ class AlbumDownloader:
             self.live_manager.update_log("CBZ creation", "No images found to archive")
             return
 
-        cbz_path = Path(self.download_path) / f"{self.album_name}.cbz"
+        cbz_path = Path(self.download_path) / f"{sanitize_directory_name(self.album_name)}.cbz"
 
         with zipfile.ZipFile(cbz_path, "w", zipfile.ZIP_DEFLATED) as cbz:
             for i, img_path in enumerate(image_files):

--- a/src/downloader/download_utils.py
+++ b/src/downloader/download_utils.py
@@ -80,7 +80,7 @@ def fetch_with_retries(
         if attempt < retries - 1:
             live_manager.update_log(
                 "Fetch attempt failed",
-                f"Fetch attemp failed for {url}. Retrying ({attempt + 1}/{retries})...",
+                f"Fetch attempt failed for {url}. Retrying ({attempt + 1}/{retries})...",
             )
             delay = 2 ** (attempt + 1) + random.uniform(1, 2)  # noqa: S311
             time.sleep(delay)

--- a/src/managers/live_manager.py
+++ b/src/managers/live_manager.py
@@ -43,9 +43,9 @@ class LiveManager:
         self.start_time = time.time()
         self.update_log("Script started", "The script has started execution.")
 
-    def add_overall_task(self, description: str, num_tasks: int) -> None:
+    def add_overall_task(self, description: str, num_tasks: int, num_pages: int) -> None:
         """Call ProgressManager to add an overall task."""
-        self.progress_manager.add_overall_task(description, num_tasks)
+        self.progress_manager.add_overall_task(description, num_tasks, num_pages)
 
     def add_task(self, current_task: int = 0, total: int = 100) -> int:
         """Call ProgressManager to add an individual task."""

--- a/src/managers/progress_manager.py
+++ b/src/managers/progress_manager.py
@@ -39,9 +39,9 @@ class ProgressManager:
         self.num_tasks = 0
         self.overall_buffer = deque(maxlen=overall_buffer_size)
 
-    def add_overall_task(self, description: str, num_tasks: int) -> None:
+    def add_overall_task(self, description: str, num_tasks: int, num_pages: int) -> None:
         """Add an overall progress task with a given description and total tasks."""
-        self.num_tasks = num_tasks
+        self.num_tasks = num_pages
         overall_description = self._adjust_description(description)
         self.overall_progress.add_task(
             f"[{self.color}]{overall_description}",
@@ -72,7 +72,7 @@ class ProgressManager:
             advance=advance if completed is None else None,
             visible=visible,
         )
-        self._update_overall_task(task_id)
+        self._update_overall_task(task_id, advance)
 
     def create_progress_table(self) -> Table:
         """Create a formatted progress table for tracking the download."""
@@ -96,14 +96,16 @@ class ProgressManager:
         return progress_table
 
     # Private methods
-    def _update_overall_task(self, task_id: int) -> None:
+    def _update_overall_task(self, task_id: int, advance: int) -> None:
         """Advance the overall progress bar and removes old tasks."""
         # Access the latest task dynamically
         current_overall_task = self.overall_progress.tasks[-1]
 
-        # If the task is finished, remove it and update the overall progress
+        # Advance the overall bar by the number of images downloaded
+        self.overall_progress.advance(current_overall_task.id, advance=advance)
+
+        # If the task is finished, remove it from display
         if self.task_progress.tasks[task_id].finished:
-            self.overall_progress.advance(current_overall_task.id)
             self.task_progress.update(task_id, visible=False)
 
         # Track completed overall tasks


### PR DESCRIPTION
## Summary
Adds comic-book (CBZ) archive output, single-URL CLI support, and several download reliability fixes.

## What changed
- **CBZ archives**: each downloaded album is packaged into a `.cbz` (zero-padded for correct page order), saved inside the album's folder, with the extracted images removed afterward.
- **CLI URL argument**: `python3 main.py <album_url>` downloads a single album; `URLs.txt` is only used (and cleared) when no URL is passed.
- **Accurate overall progress**: the progress bar now advances per downloaded image against the album's total image count, not per page.
- **Resume safety**: downloads write to `.part` temp files first, so interrupted runs can't leave fake-complete images.
- **Bug fixes**: single-page albums no longer crash; missing image/`nl` elements are handled gracefully; CBZ page ordering is preserved; album titles with characters like `/` no longer break paths.

## Testing
- All modules pass `python3 -m py_compile`.
- Verified resume mapping, CBZ ordering/packaging, and overall progress logic manually.